### PR TITLE
feat(Malimbe): remove malimbe dependency

### DIFF
--- a/Documentation/API/MovementAmplifierFacade.md
+++ b/Documentation/API/MovementAmplifierFacade.md
@@ -14,6 +14,8 @@ The public interface for the MovementAmplifier prefab.
   * [Source]
   * [Target]
 * [Methods]
+  * [ClearSource()]
+  * [ClearTarget()]
   * [OnAfterIgnoredRadiusChange()]
   * [OnAfterMultiplierChange()]
   * [OnAfterSourceChange()]
@@ -90,6 +92,26 @@ public GameObject Target { get; set; }
 
 ### Methods
 
+#### ClearSource()
+
+Clears [Source].
+
+##### Declaration
+
+```
+public virtual void ClearSource()
+```
+
+#### ClearTarget()
+
+Clears [Target].
+
+##### Declaration
+
+```
+public virtual void ClearTarget()
+```
+
 #### OnAfterIgnoredRadiusChange()
 
 Called after [IgnoredRadius] has been changed.
@@ -135,6 +157,8 @@ protected virtual void OnAfterTargetChange()
 [Source]: MovementAmplifierFacade.md#Source
 [Source]: MovementAmplifierFacade.md#Source
 [Target]: MovementAmplifierFacade.md#Target
+[Source]: MovementAmplifierFacade.md#Source
+[Target]: MovementAmplifierFacade.md#Target
 [IgnoredRadius]: MovementAmplifierFacade.md#IgnoredRadius
 [Multiplier]: MovementAmplifierFacade.md#Multiplier
 [Source]: MovementAmplifierFacade.md#Source
@@ -149,6 +173,8 @@ protected virtual void OnAfterTargetChange()
 [Source]: #Source
 [Target]: #Target
 [Methods]: #Methods
+[ClearSource()]: #ClearSource
+[ClearTarget()]: #ClearTarget
 [OnAfterIgnoredRadiusChange()]: #OnAfterIgnoredRadiusChange
 [OnAfterMultiplierChange()]: #OnAfterMultiplierChange
 [OnAfterSourceChange()]: #OnAfterSourceChange

--- a/FodyWeavers.xml
+++ b/FodyWeavers.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<Weavers>
-  <Malimbe.FodyRunner>
-    <AssemblyNameRegex>^Tilia.Locomotors.MovementAmplifier</AssemblyNameRegex>
-  </Malimbe.FodyRunner>
-</Weavers>

--- a/FodyWeavers.xml.meta
+++ b/FodyWeavers.xml.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: b7df3cf279246f84faae38274f94d05e
-TextScriptImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Runtime/SharedResources/Scripts/MovementAmplifierConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/MovementAmplifierConfigurator.cs
@@ -1,13 +1,11 @@
 namespace Tilia.Locomotors.MovementAmplifier
 {
     using UnityEngine;
-    using Malimbe.XmlDocumentationAttribute;
-    using Malimbe.PropertySerializationAttribute;
-    using Zinnia.Extension;
-    using Zinnia.Tracking.Follow;
     using Zinnia.Data.Attribute;
     using Zinnia.Data.Operation.Mutation;
     using Zinnia.Data.Type.Transformation.Aggregation;
+    using Zinnia.Extension;
+    using Zinnia.Tracking.Follow;
 
     /// <summary>
     /// Sets up the MovementAmplifier prefab based on the provided user settings.
@@ -15,57 +13,155 @@ namespace Tilia.Locomotors.MovementAmplifier
     public class MovementAmplifierConfigurator : MonoBehaviour
     {
         #region Facade Settings
+        [Header("Facade Settings")]
+        [Tooltip("The public interface facade.")]
+        [SerializeField]
+        [Restricted]
+        private MovementAmplifierFacade facade;
         /// <summary>
         /// The public interface facade.
         /// </summary>
-        [Serialized]
-        [field: Header("Facade Settings"), DocumentedByXml, Restricted]
-        public MovementAmplifierFacade Facade { get; protected set; }
+        public MovementAmplifierFacade Facade
+        {
+            get
+            {
+                return facade;
+            }
+            protected set
+            {
+                facade = value;
+            }
+        }
         #endregion
 
         #region Reference Settings
+        [Header("Reference Settings")]
+        [Tooltip("The public interface facade.")]
+        [SerializeField]
+        [Restricted]
+        private ObjectDistanceComparator radiusOriginMover;
         /// <summary>
         /// Moves the radius origin.
         /// </summary>
-        [Serialized]
-        [field: Header("Reference Settings"), DocumentedByXml, Restricted]
-        public ObjectDistanceComparator RadiusOriginMover { get; protected set; }
+        public ObjectDistanceComparator RadiusOriginMover
+        {
+            get
+            {
+                return radiusOriginMover;
+            }
+            protected set
+            {
+                radiusOriginMover = value;
+            }
+        }
+        [Tooltip("Determines whether MovementAmplifierFacade.Source is inside the radius.")]
+        [SerializeField]
+        [Restricted]
+        private ObjectDistanceComparator distanceChecker;
         /// <summary>
         /// Determines whether <see cref="MovementAmplifierFacade.Source"/> is inside the radius.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml, Restricted]
-        public ObjectDistanceComparator DistanceChecker { get; protected set; }
+        public ObjectDistanceComparator DistanceChecker
+        {
+            get
+            {
+                return distanceChecker;
+            }
+            protected set
+            {
+                distanceChecker = value;
+            }
+        }
+        [Tooltip("Moves the objects.")]
+        [SerializeField]
+        [Restricted]
+        private ObjectDistanceComparator objectMover;
         /// <summary>
         /// Moves the objects.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml, Restricted]
-        public ObjectDistanceComparator ObjectMover { get; protected set; }
+        public ObjectDistanceComparator ObjectMover
+        {
+            get
+            {
+                return objectMover;
+            }
+            protected set
+            {
+                objectMover = value;
+            }
+        }
+        [Tooltip("Subtracts the radius.")]
+        [SerializeField]
+        [Restricted]
+        private FloatAdder radiusSubtractor;
         /// <summary>
         /// Subtracts the radius.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml, Restricted]
-        public FloatAdder RadiusSubtractor { get; protected set; }
+        public FloatAdder RadiusSubtractor
+        {
+            get
+            {
+                return radiusSubtractor;
+            }
+            protected set
+            {
+                radiusSubtractor = value;
+            }
+        }
+        [Tooltip("Stabilizes the radius by ensuring MovementAmplifierFacade.Target moves back into the radius.")]
+        [SerializeField]
+        [Restricted]
+        private float radiusStabilizer = 0.001f;
         /// <summary>
         /// Stabilizes the radius by ensuring <see cref="MovementAmplifierFacade.Target"/> moves back into the radius.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml, Restricted]
-        public float RadiusStabilizer { get; protected set; } = 0.001f;
+        public float RadiusStabilizer
+        {
+            get
+            {
+                return radiusStabilizer;
+            }
+            protected set
+            {
+                radiusStabilizer = value;
+            }
+        }
+        [Tooltip("Amplifies the movement.")]
+        [SerializeField]
+        [Restricted]
+        private Vector3Multiplier movementMultiplier;
         /// <summary>
         /// Amplifies the movement.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml, Restricted]
-        public Vector3Multiplier MovementMultiplier { get; protected set; }
+        public Vector3Multiplier MovementMultiplier
+        {
+            get
+            {
+                return movementMultiplier;
+            }
+            protected set
+            {
+                movementMultiplier = value;
+            }
+        }
+        [Tooltip("Moves the target.")]
+        [SerializeField]
+        [Restricted]
+        private TransformPositionMutator targetPositionMutator;
         /// <summary>
         /// Moves the target.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml, Restricted]
-        public TransformPositionMutator TargetPositionMutator { get; protected set; }
+        public TransformPositionMutator TargetPositionMutator
+        {
+            get
+            {
+                return targetPositionMutator;
+            }
+            protected set
+            {
+                targetPositionMutator = value;
+            }
+        }
         #endregion
 
         /// <summary>

--- a/Runtime/SharedResources/Scripts/MovementAmplifierFacade.cs
+++ b/Runtime/SharedResources/Scripts/MovementAmplifierFacade.cs
@@ -1,11 +1,8 @@
 namespace Tilia.Locomotors.MovementAmplifier
 {
     using UnityEngine;
-    using Malimbe.MemberChangeMethod;
-    using Malimbe.MemberClearanceMethod;
-    using Malimbe.XmlDocumentationAttribute;
-    using Malimbe.PropertySerializationAttribute;
     using Zinnia.Data.Attribute;
+    using Zinnia.Extension;
 
     /// <summary>
     /// The public interface for the MovementAmplifier prefab.
@@ -13,48 +10,148 @@ namespace Tilia.Locomotors.MovementAmplifier
     public class MovementAmplifierFacade : MonoBehaviour
     {
         #region Tracking Settings
+        [Header("Tracking Settings")]
+        [Tooltip("The source to observe movement of.")]
+        [SerializeField]
+        private GameObject source;
         /// <summary>
         /// The source to observe movement of.
         /// </summary>
-        [Serialized, Cleared]
-        [field: Header("Tracking Settings"), DocumentedByXml]
-        public GameObject Source { get; set; }
+        public GameObject Source
+        {
+            get
+            {
+                return source;
+            }
+            set
+            {
+                source = value;
+                if (this.IsMemberChangeAllowed())
+                {
+                    OnAfterSourceChange();
+                }
+            }
+        }
+        [Tooltip("The target to apply amplified movement to.")]
+        [SerializeField]
+        private GameObject target;
         /// <summary>
         /// The target to apply amplified movement to.
         /// </summary>
-        [Serialized, Cleared]
-        [field: DocumentedByXml]
-        public GameObject Target { get; set; }
+        public GameObject Target
+        {
+            get
+            {
+                return target;
+            }
+            set
+            {
+                target = value;
+                if (this.IsMemberChangeAllowed())
+                {
+                    OnAfterTargetChange();
+                }
+            }
+        }
         #endregion
 
         #region Movement Settings
+        [Header("Movement Settings")]
+        [Tooltip("The radius in which Source movement is ignored. Too small values can result in movement amplification happening during crouching which is often unexpected.")]
+        [SerializeField]
+        private float ignoredRadius = 0.25f;
         /// <summary>
         /// The radius in which <see cref="Source"/> movement is ignored. Too small values can result in movement amplification happening during crouching which is often unexpected.
         /// </summary>
-        [Serialized]
-        [field: Header("Movement Settings"), DocumentedByXml]
-        public float IgnoredRadius { get; set; } = 0.25f;
+        public float IgnoredRadius
+        {
+            get
+            {
+                return ignoredRadius;
+            }
+            set
+            {
+                ignoredRadius = value;
+                if (this.IsMemberChangeAllowed())
+                {
+                    OnAfterIgnoredRadiusChange();
+                }
+            }
+        }
+        [Tooltip("How much to amplify movement of Source to apply to Target.")]
+        [SerializeField]
+        private float multiplier = 2f;
         /// <summary>
         /// How much to amplify movement of <see cref="Source"/> to apply to <see cref="Target"/>.
         /// </summary>
-        [Serialized]
-        [field: DocumentedByXml]
-        public float Multiplier { get; set; } = 2f;
+        public float Multiplier
+        {
+            get
+            {
+                return multiplier;
+            }
+            set
+            {
+                multiplier = value;
+                if (this.IsMemberChangeAllowed())
+                {
+                    OnAfterMultiplierChange();
+                }
+            }
+        }
         #endregion
 
         #region Reference Settings
+        [Header("Reference Settings")]
+        [Tooltip("The linked Internal Setup.")]
+        [SerializeField]
+        [Restricted]
+        private MovementAmplifierConfigurator configuration;
         /// <summary>
         /// The linked Internal Setup.
         /// </summary>
-        [Serialized]
-        [field: Header("Reference Settings"), DocumentedByXml, Restricted]
-        public MovementAmplifierConfigurator Configuration { get; protected set; }
+        public MovementAmplifierConfigurator Configuration
+        {
+            get
+            {
+                return configuration;
+            }
+            protected set
+            {
+                configuration = value;
+            }
+        }
         #endregion
+
+        /// <summary>
+        /// Clears <see cref="Source"/>.
+        /// </summary>
+        public virtual void ClearSource()
+        {
+            if (!this.IsValidState())
+            {
+                return;
+            }
+
+            Source = default;
+        }
+
+        /// <summary>
+        /// Clears <see cref="Target"/>.
+        /// </summary>
+        public virtual void ClearTarget()
+        {
+            if (!this.IsValidState())
+            {
+                return;
+            }
+
+            Target = default;
+        }
 
         /// <summary>
         /// Called after <see cref="Source"/> has been changed.
         /// </summary>
-        [CalledAfterChangeOf(nameof(Source))]
         protected virtual void OnAfterSourceChange()
         {
             Configuration.ConfigureRadiusOriginMover();
@@ -65,7 +162,6 @@ namespace Tilia.Locomotors.MovementAmplifier
         /// <summary>
         /// Called after <see cref="Target"/> has been changed.
         /// </summary>
-        [CalledAfterChangeOf(nameof(Target))]
         protected virtual void OnAfterTargetChange()
         {
             Configuration.ConfigureTargetPositionMutator();
@@ -74,7 +170,6 @@ namespace Tilia.Locomotors.MovementAmplifier
         /// <summary>
         /// Called after <see cref="IgnoredRadius"/> has been changed.
         /// </summary>
-        [CalledAfterChangeOf(nameof(IgnoredRadius))]
         protected virtual void OnAfterIgnoredRadiusChange()
         {
             Configuration.ConfigureDistanceChecker();
@@ -84,7 +179,6 @@ namespace Tilia.Locomotors.MovementAmplifier
         /// <summary>
         /// Called after <see cref="Multiplier"/> has been changed.
         /// </summary>
-        [CalledAfterChangeOf(nameof(Multiplier))]
         protected virtual void OnAfterMultiplierChange()
         {
             Configuration.ConfigureMovementMultiplier();

--- a/Runtime/Tilia.Locomotors.MovementAmplifier.Unity.Runtime.asmdef
+++ b/Runtime/Tilia.Locomotors.MovementAmplifier.Unity.Runtime.asmdef
@@ -8,13 +8,7 @@
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": true,
-    "precompiledReferences": [
-        "Malimbe.BehaviourStateRequirementMethod.dll",
-        "Malimbe.MemberChangeMethod.dll",
-        "Malimbe.MemberClearanceMethod.dll",
-        "Malimbe.PropertySerializationAttribute.dll",
-        "Malimbe.XmlDocumentationAttribute.dll"
-    ],
+    "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": []
 }


### PR DESCRIPTION
BREAKING CHANGE: This removes the last remaining elements of
Malimbe and whilst it does not cause any breaking changes within
this package, it removes Malimbe as a dependency which other projects
that rely on this package may piggy back off this Malimbe dependency
so it will break any project like that.

All of the previous functionality from Malimbe has been replicated in
standard code without the need for it to be weaved by the Malimbe
helper tags.